### PR TITLE
Add calendar extension in php81-pipeline image

### DIFF
--- a/php-vapor/php81-pipeline/Dockerfile
+++ b/php-vapor/php81-pipeline/Dockerfile
@@ -9,7 +9,8 @@ RUN pecl install pcov && \
 
 # Added for better RSA encryption/decryption
 RUN apk --update add gmp-dev && \
-    docker-php-ext-install gmp
+    docker-php-ext-install gmp && \
+    docker-php-ext-install calendar
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 


### PR DESCRIPTION
Currently it is necessary to install the extension during the execution of the pipeline, this generates additional time, which can be omitted by installing it directly on the image.