### PR TITLE
feat(docker): update php82-cloudhsm to bullseye & ext installer

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,7 @@ if [ -z "$PHP_VERSION" ]; then
   echo -e "\tphp81-pipeline"
 
   echo -e "\tphp82"
+  echo -e "\tphp82-cloudhsm"
   echo -e "\tphp82-pipeline"
   echo -e "\tphp82-arm"
   echo -e "\tphp82-arm-pipeline"

--- a/php-vapor/php82-cloudhsm/Dockerfile
+++ b/php-vapor/php82-cloudhsm/Dockerfile
@@ -1,10 +1,10 @@
-FROM --platform=linux/amd64 php:8.2-fpm-buster
+FROM --platform=linux/amd64 php:8.2-fpm-bullseye
 
 # Install `docker-php-ext-install` helper to ease installation of PHP
 # extensions
 #
 # Ref: https://github.com/mlocati/docker-php-extension-installer
-ENV PHP_EXT_INSTALLER_VERSION=2.1.80
+ENV PHP_EXT_INSTALLER_VERSION=2.8.5
 
 RUN set -eux; \
       curl --fail -Lo /usr/local/bin/install-php-extensions \


### PR DESCRIPTION
Switch base image to php:8.2-fpm-bullseye and update the PHP extension installer to version 2.8.5 for php82-cloudhsm. Add missing newline at end of Dockerfile. Update build.sh to include php82-cloudhsm as an option.